### PR TITLE
fix: Request camera/mic permissions on MacOS

### DIFF
--- a/app-resources/Coollab-Launcher.app/Contents/Info.plist
+++ b/app-resources/Coollab-Launcher.app/Contents/Info.plist
@@ -35,6 +35,12 @@
         <key>NSRemovableVolumesUsageDescription</key>
         <string>Coollab Launcher needs access to external drives to save and load projects.</string>
 
+        <key>NSMicrophoneUsageDescription</key>
+        <string>Coollab would like to access the microphone for audio input usage</string>
+
+        <key>NSCameraUsageDescription</key>
+        <string>Coollab would like to access the camera for webcam node usage</string>
+
         <key>CFBundleDocumentTypes</key>
         <array>
             <dict>


### PR DESCRIPTION
closes #2 

# Testing

Note: I haven't got a lot of experience developing for MacOS, so apologies if my methodology is a bit crude 😄 

The steps I took were the following:
* Download the app from the usual download link
* Modify the Info.plist file to add camera and mic permissions
* Re-sign the app

During first launch: 

<img width="281" height="276" alt="image" src="https://github.com/user-attachments/assets/5e4e0018-bc2f-4bee-bf00-3fbe8b8458bb" /> 

(same for the mic)

Afterwards:

<img width="481" height="230" alt="image" src="https://github.com/user-attachments/assets/54cf99d2-a1f9-43ca-9067-0fd1d62d9e93" />

<img width="481" height="172" alt="image" src="https://github.com/user-attachments/assets/595b3b7a-0dcc-46f1-b0a4-4298096f7ce0" />


Thanks and looking forward to playing around with Coollab!
